### PR TITLE
Fix TypeScript build for git installs

### DIFF
--- a/packages/tenancy/src/env.d.ts
+++ b/packages/tenancy/src/env.d.ts
@@ -1,0 +1,3 @@
+declare const process: {
+  env: Record<string, string | undefined>;
+};

--- a/packages/tenancy/src/shims.d.ts
+++ b/packages/tenancy/src/shims.d.ts
@@ -1,0 +1,76 @@
+declare module '@nestjs/common' {
+  export function Injectable(): ClassDecorator;
+  export function Global(): ClassDecorator;
+  export function Module(metadata: {
+    providers?: unknown[];
+    exports?: unknown[];
+    imports?: unknown[];
+  }): ClassDecorator;
+  export class Logger {
+    constructor(context: string);
+    log(message: string, ...optionalParams: unknown[]): void;
+    warn(message: string, ...optionalParams: unknown[]): void;
+    error(message: string, ...optionalParams: unknown[]): void;
+  }
+}
+
+declare module '@prisma/client' {
+  export interface DatasourceConfig {
+    url?: string;
+  }
+  export interface DatasourceOptions {
+    db?: DatasourceConfig;
+  }
+  export interface PrismaClientOptions {
+    datasources?: DatasourceOptions;
+  }
+  export class PrismaClient {
+    constructor(options?: PrismaClientOptions);
+    $disconnect(): Promise<void>;
+  }
+}
+
+declare module 'firebase-admin/firestore' {
+  export interface FirestoreQuerySnapshot {
+    empty: boolean;
+    docs: Array<{
+      id: string;
+      data(): any;
+    }>;
+  }
+
+  export interface FirestoreDocumentSnapshot {
+    id: string;
+    exists: boolean;
+    data(): any;
+  }
+
+  export interface FirestoreCollectionReference {
+    doc(id: string): { get(): Promise<FirestoreDocumentSnapshot> };
+    where(fieldPath: string, opStr: FirebaseFirestore.WhereFilterOp, value: unknown): FirestoreQuery;
+    limit(count: number): FirestoreQuery;
+    get(): Promise<FirestoreQuerySnapshot>;
+  }
+
+  export interface FirestoreQuery {
+    where(fieldPath: string, opStr: FirebaseFirestore.WhereFilterOp, value: unknown): FirestoreQuery;
+    limit(count: number): FirestoreQuery;
+    get(): Promise<FirestoreQuerySnapshot>;
+  }
+
+  export class Firestore {
+    collection(collectionPath: string): FirestoreCollectionReference;
+  }
+}
+
+declare namespace FirebaseFirestore {
+  type WhereFilterOp = '<' | '<=' | '==' | '!=' | '>=' | '>' | 'array-contains' | 'in' | 'array-contains-any' | 'not-in';
+}
+
+declare module 'ioredis' {
+  export interface Redis {
+    get(key: string): Promise<string | null>;
+    set(key: string, value: string, mode?: string, duration?: number): Promise<'OK' | null>;
+    del(...keys: string[]): Promise<number>;
+  }
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,9 +1,13 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "packages/tenancy/src",
     "outDir": "dist",
     "declaration": true
   },
-  "include": ["src"]
+  "include": [
+    "packages/tenancy/src/**/*.ts",
+    "packages/tenancy/src/**/*.d.ts"
+  ],
+  "exclude": ["dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,12 @@
 {
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2021",
-    "lib": ["ES2021"],
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "declaration": true,
+    "rootDir": "packages/tenancy/src",
     "outDir": "dist",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true
+    "types": []
   },
-  "include": ["src", "test"]
+  "include": [
+    "packages/tenancy/src/**/*.ts",
+    "packages/tenancy/src/**/*.d.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- point the root TypeScript configs at the package sources so the prepare step can compile when installed from git
- add lightweight type shims for peer dependencies to allow building without installing them locally

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bd6e70248325ba482b5cf756f868