### PR TITLE
Use type-only Firestore import to avoid Node require bug

### DIFF
--- a/packages/tenancy/src/services/tenant.service.ts
+++ b/packages/tenancy/src/services/tenant.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Firestore } from 'firebase-admin/firestore';
-import { PrismaClient } from '@prisma/client';
+import type { Firestore } from 'firebase-admin/firestore';
+import type { PrismaClient } from '@prisma/client';
 import { TenantCacheService } from './tenant-cache.service';
 import { PrismaPoolService } from './prisma-pool.service';
 import { ResolveInput, TenantDoc } from '../types';


### PR DESCRIPTION
## Summary
- switch the Firestore and PrismaClient imports in the tenant service to type-only imports so runtime code no longer requires firebase-admin subpath modules

## Testing
- ./packages/tenancy/node_modules/.bin/tsc -p packages/tenancy/tsconfig.build.json
- ./packages/tenancy/node_modules/.bin/tsc -p packages/tenancy/tsconfig.build.cjs.json

------
https://chatgpt.com/codex/tasks/task_e_68c9c513d5f08325a6f90b582eb2e246