### PR TITLE
fix: stub missing type libraries

### DIFF
--- a/src/shims.d.ts
+++ b/src/shims.d.ts
@@ -84,3 +84,17 @@ declare module 'ioredis' {
     del(...keys: string[]): Promise<number>;
   }
 }
+
+// Node Globals
+declare namespace NodeJS {
+  interface ProcessEnv {
+    TENANT_PRISMA_CACHE_TTL_MS?: string;
+    TENANT_PRISMA_CACHE_MAX?: string;
+    TENANT_CACHE_TTL_SECONDS?: string;
+    [key: string]: string | undefined;
+  }
+}
+
+declare const process: {
+  env: NodeJS.ProcessEnv;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "skipLibCheck": true,
     "declaration": true,
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": []
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- stop forcing TypeScript to load unavailable scoped typings by clearing the compiler `types` list
- add minimal Node.js environment declarations so the library still has typed `process.env` access when Node typings are absent

## Testing
- node packages/tenancy/node_modules/typescript/lib/tsc -p tsconfig.build.esm.json
- node packages/tenancy/node_modules/typescript/lib/tsc -p tsconfig.build.cjs.json

------
https://chatgpt.com/codex/tasks/task_e_68c9e96c1280832597571d0f879511c6