### PR TITLE
feat: secure tenant context secrets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,7 @@ export * from './tenant.module';
 export * from './services/tenant.service';
 export * from './services/tenant-cache.service';
 export * from './services/prisma-pool.service';
+export * from './services/tenant-context.service';
+export * from './services/tenant-secret-vault.service';
 export * from './types';
 export * from './tenancy.constants';

--- a/src/services/tenant-context.service.ts
+++ b/src/services/tenant-context.service.ts
@@ -1,0 +1,82 @@
+// Dependencies
+import { Injectable, Logger } from '@nestjs/common';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { PrismaClient } from '@prisma/client';
+
+// Types
+import type {
+  TenantContextSnapshot,
+  TenantContextState,
+  TenantSecretBundle,
+  TenantSnapshot,
+} from '../types';
+
+// Utils
+const cloneTenant = (tenant: TenantSnapshot): TenantSnapshot => ({
+  ...tenant,
+  microsoft: tenant.microsoft ? { ...tenant.microsoft } : undefined,
+});
+
+@Injectable()
+export class TenantContextService {
+  private readonly logger = new Logger(TenantContextService.name);
+  private readonly storage = new AsyncLocalStorage<TenantContextState>();
+
+  // Services
+
+  async runWithTenant<T>(snapshot: TenantContextSnapshot, handler: () => Promise<T>): Promise<T> {
+    const metadata = Object.freeze({ ...snapshot.metadata });
+    const state: TenantContextState = Object.freeze({
+      tenant: Object.freeze(cloneTenant(snapshot.tenant)),
+      prisma: snapshot.prisma,
+      metadata,
+      secrets: snapshot.secrets,
+      createdAt: new Date(),
+    });
+
+    return this.storage.run(state, async () => {
+      try {
+        return await handler();
+      } catch (error) {
+        this.logger.error('Unhandled error inside tenant context', error as Error);
+        throw error;
+      }
+    });
+  }
+
+  getContext(): TenantContextState | undefined {
+    return this.storage.getStore();
+  }
+
+  isActive(): boolean {
+    return Boolean(this.getContext());
+  }
+
+  getTenant(): TenantSnapshot {
+    const context = this.getRequiredContext();
+    return context.tenant;
+  }
+
+  getPrismaClient(): PrismaClient {
+    const context = this.getRequiredContext();
+    return context.prisma;
+  }
+
+  getMetadata(): TenantContextState['metadata'] {
+    const context = this.getRequiredContext();
+    return context.metadata;
+  }
+
+  getSecrets(): TenantSecretBundle {
+    const context = this.getRequiredContext();
+    return context.secrets;
+  }
+
+  private getRequiredContext(): TenantContextState {
+    const context = this.getContext();
+    if (!context) {
+      throw new Error('Tenant context is not available in the current execution scope.');
+    }
+    return context;
+  }
+}

--- a/src/services/tenant-secret-vault.service.ts
+++ b/src/services/tenant-secret-vault.service.ts
@@ -1,0 +1,68 @@
+// Dependencies
+import { Injectable, Logger } from '@nestjs/common';
+import { createSecretKey } from 'node:crypto';
+
+// Types
+import type { TenantDoc, TenantSecretBundle, TenantSnapshot } from '../types';
+
+// Utils
+const cloneWithoutSecrets = (tenant: TenantDoc): TenantSnapshot => {
+  if (!tenant.microsoft) {
+    return Object.freeze({ ...tenant }) as TenantSnapshot;
+  }
+
+  const { GRAPH_CLIENT_SECRET: _secret, ...safeMicrosoft } = tenant.microsoft;
+  return Object.freeze({
+    ...tenant,
+    microsoft: Object.freeze({ ...safeMicrosoft }),
+  }) as TenantSnapshot;
+};
+
+@Injectable()
+export class TenantSecretVaultService {
+  private readonly logger = new Logger(TenantSecretVaultService.name);
+  private readonly vault = new Map<string, TenantSecretBundle>();
+
+  // Services
+
+  sanitizeTenant(tenant: TenantDoc): TenantSnapshot {
+    return cloneWithoutSecrets(tenant);
+  }
+
+  captureFromTenant(tenant: TenantDoc): TenantSecretBundle {
+    try {
+      const secrets = this.buildBundle(tenant);
+      this.vault.set(tenant.id, secrets);
+      return secrets;
+    } catch (error) {
+      this.logger.error(`Failed to create secret bundle for tenant ${tenant.id}`, error as Error);
+      throw error;
+    }
+  }
+
+  getSecrets(tenantId: string): TenantSecretBundle | undefined {
+    const entry = this.vault.get(tenantId);
+    if (!entry) return undefined;
+    return entry;
+  }
+
+  clearSecrets(tenantId: string): void {
+    this.vault.delete(tenantId);
+  }
+
+  // Utils
+
+  private buildBundle(tenant: TenantDoc): TenantSecretBundle {
+    if (!tenant.microsoft?.GRAPH_CLIENT_SECRET) {
+      return Object.freeze({}) as TenantSecretBundle;
+    }
+
+    const clientSecret = createSecretKey(Buffer.from(tenant.microsoft.GRAPH_CLIENT_SECRET, 'utf8'));
+    const bundle: TenantSecretBundle = Object.freeze({
+      microsoft: Object.freeze({
+        clientSecret,
+      }),
+    });
+    return bundle;
+  }
+}

--- a/src/tenant.module.ts
+++ b/src/tenant.module.ts
@@ -8,6 +8,8 @@ import Redis from 'ioredis';
 import { TenantCacheService } from './services/tenant-cache.service';
 import { PrismaPoolService } from './services/prisma-pool.service';
 import { TenantService } from './services/tenant.service';
+import { TenantContextService } from './services/tenant-context.service';
+import { TenantSecretVaultService } from './services/tenant-secret-vault.service';
 
 // Utils
 import { FIRESTORE_PROVIDER, REDIS_PROVIDER } from './tenancy.constants';
@@ -63,14 +65,32 @@ const prismaPoolProvider: Provider = {
   useFactory: (): PrismaPoolService => new PrismaPoolService(),
 };
 
+const tenantContextProvider: Provider = {
+  provide: TenantContextService,
+  useFactory: (): TenantContextService => new TenantContextService(),
+};
+
+const tenantSecretVaultProvider: Provider = {
+  provide: TenantSecretVaultService,
+  useFactory: (): TenantSecretVaultService => new TenantSecretVaultService(),
+};
+
 const tenantServiceProvider: Provider = {
   provide: TenantService,
   useFactory: (
     firestore: Firestore,
     cache: TenantCacheService,
     prismaPool: PrismaPoolService,
-  ): TenantService => new TenantService(firestore, cache, prismaPool),
-  inject: [FIRESTORE_PROVIDER, TenantCacheService, PrismaPoolService],
+    secretVault: TenantSecretVaultService,
+    context: TenantContextService,
+  ): TenantService => new TenantService(firestore, cache, prismaPool, secretVault, context),
+  inject: [
+    FIRESTORE_PROVIDER,
+    TenantCacheService,
+    PrismaPoolService,
+    TenantSecretVaultService,
+    TenantContextService,
+  ],
 };
 
 @Global()
@@ -80,8 +100,16 @@ const tenantServiceProvider: Provider = {
     redisProvider,
     tenantCacheProvider,
     prismaPoolProvider,
+    tenantContextProvider,
+    tenantSecretVaultProvider,
     tenantServiceProvider,
   ],
-  exports: [TenantService, TenantCacheService, PrismaPoolService],
+  exports: [
+    TenantService,
+    TenantCacheService,
+    PrismaPoolService,
+    TenantContextService,
+    TenantSecretVaultService,
+  ],
 })
 export class TenantModule {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
+// Dependencies
+import type { PrismaClient } from '@prisma/client';
+import type { KeyObject } from 'node:crypto';
+
+// Types
 export interface TenantMicrosoftConfig {
   GRAPH_TENANT_ID: string;
   GRAPH_CLIENT_ID: string;
-  GRAPH_CLIENT_SECRET: string;
+  GRAPH_CLIENT_SECRET?: string;
   GRAPH_REDIRECT_URI?: string;
   GRAPH_SCOPE?: string;
 }
@@ -14,7 +19,39 @@ export interface TenantDoc {
   microsoft?: TenantMicrosoftConfig;
 }
 
+export type TenantSnapshot = Omit<TenantDoc, 'microsoft'> & {
+  readonly microsoft?: Omit<TenantMicrosoftConfig, 'GRAPH_CLIENT_SECRET'>;
+};
+
 export interface ResolveInput {
   tenantId?: string;
   userId?: string;
+}
+
+export type TenantContextSource =
+  | 'tenantId'
+  | 'userId'
+  | 'workspaceTenantId'
+  | 'microsoftTenantId';
+
+export interface TenantContextMetadata {
+  readonly source: TenantContextSource;
+  readonly identifier: string;
+}
+
+export interface TenantContextSnapshot {
+  readonly tenant: TenantSnapshot;
+  readonly prisma: PrismaClient;
+  readonly metadata: TenantContextMetadata;
+  readonly secrets: TenantSecretBundle;
+}
+
+export interface TenantContextState extends TenantContextSnapshot {
+  readonly createdAt: Date;
+}
+
+export interface TenantSecretBundle {
+  readonly microsoft?: {
+    readonly clientSecret: KeyObject;
+  };
 }


### PR DESCRIPTION
## Summary
- add TenantSecretVaultService to sanitize tenant payloads and store secrets as KeyObjects for reuse across requests
- update TenantService and TenantContextService to hydrate cached tenants through the vault and expose secrets via AsyncLocalStorage
- expand documentation and exports so consumers understand how to access the vault and secret-aware context helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc263d2ad48325a78e205442e2e232