### PR TITLE
Fix TypeScript configuration for Node built-ins

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "skipLibCheck": true,
     "declaration": true,
     "resolveJsonModule": true,
-    "types": []
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
## Summary
- include Node type definitions in the base TypeScript configuration to allow building with node:* imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd79abcc2883258998b18aac575883