### PR TITLE
Add Qdrant tenant secrets support and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,9 @@ Responsável por isolar informações sensíveis de cada tenant e fornecer snaps
 
 | Função | Quando usar | Comportamento |
 | --- | --- | --- |
-| `sanitizeTenant(tenant: TenantDoc): TenantSnapshot` | Antes de compartilhar dados de tenant com consumidores que não devem ver segredos. | Remove `GRAPH_CLIENT_SECRET`, congela objetos internos e retorna um `TenantSnapshot` seguro. |
-| `captureFromTenant(tenant: TenantDoc): TenantSecretBundle` | Ao registrar/atualizar tenants contendo secrets que precisam ser reutilizados. | Constrói `TenantSecretBundle` com `KeyObject` derivado do secret, armazena no vault interno e retorna a instância congelada. |
-| `getSecrets(tenantId: string): TenantSecretBundle \| undefined` | Para recuperar secrets previamente capturados ao montar contexto ou executar integrações. | Busca no vault em memória e retorna bundle (imutável) ou `undefined` quando inexistente. |
+| `sanitizeTenant(tenant: TenantDoc): TenantSnapshot` | Antes de compartilhar dados de tenant com consumidores que não devem ver segredos. | Remove `GRAPH_CLIENT_SECRET` e `QDRANT_API_KEY`, congela objetos internos e retorna um `TenantSnapshot` seguro. |
+| `captureFromTenant(tenant: TenantDoc): TenantSecretBundle` | Ao registrar/atualizar tenants contendo secrets que precisam ser reutilizados. | Constrói `TenantSecretBundle` com `KeyObject` derivado dos secrets (Microsoft e Qdrant), armazena no vault interno e retorna a instância congelada. |
+| `getSecrets(tenantId: string): TenantSecretBundle \| undefined` | Para recuperar secrets previamente capturados ao montar contexto ou executar integrações. | Busca no vault em memória e retorna bundle (imutável) com segredos Microsoft/Qdrant ou `undefined` quando inexistente. |
 | `clearSecrets(tenantId: string): void` | Quando um tenant é desativado/rotacionado e os secrets não devem permanecer em memória. | Remove a entrada correspondente no vault. |
 
 ### `TenantWorkspaceRunner`
@@ -232,9 +232,10 @@ Módulo global NestJS que disponibiliza todos os serviços acima via injeção d
 | Type | Quando usar | Propriedades relevantes |
 | --- | --- | --- |
 | `TenantMicrosoftConfig` | Representar configuração Microsoft Graph de um tenant sempre que dados completos (incluindo secret opcional) forem necessários para autenticação OAuth. | `GRAPH_TENANT_ID`, `GRAPH_CLIENT_ID`, `GRAPH_CLIENT_SECRET?`, `GRAPH_REDIRECT_URI?`, `GRAPH_SCOPE?`. |
-| `TenantDoc` | Mapear o documento persistido no Firestore, normalmente retornado por `TenantService.getTenantById`/`getWorkspaceByMicrosoft`. | `id`, `db`, `name?`, `active?`, `microsoft?`. |
-| `TenantSnapshot` | Compartilhar informações de tenant com segurança (sem secrets) entre handlers/contexto. | Mesmos campos de `TenantDoc`, mas com `microsoft` sem `GRAPH_CLIENT_SECRET`. |
-| `TenantSecretBundle` | Armazenar de forma imutável secrets sensíveis capturados pelo `TenantSecretVaultService`. | `microsoft?.clientSecret` (`KeyObject`). |
+| `TenantQdrantConfig` | Descrever a configuração da integração com o Qdrant persistida por tenant. | `QDRANT_URL`, `QDRANT_API_KEY?`. |
+| `TenantDoc` | Mapear o documento persistido no Firestore, normalmente retornado por `TenantService.getTenantById`/`getWorkspaceByMicrosoft`. | `id`, `db`, `name?`, `active?`, `microsoft?`, `qdrant?`. |
+| `TenantSnapshot` | Compartilhar informações de tenant com segurança (sem secrets) entre handlers/contexto. | Mesmos campos de `TenantDoc`, mas com `microsoft` sem `GRAPH_CLIENT_SECRET` e `qdrant` sem `QDRANT_API_KEY`. |
+| `TenantSecretBundle` | Armazenar de forma imutável secrets sensíveis capturados pelo `TenantSecretVaultService`. | `microsoft?.clientSecret` (`KeyObject`), `qdrant?.apiKey` (`KeyObject`). |
 
 ### Resolução e contexto
 | Type | Quando usar | Propriedades relevantes |

--- a/src/services/tenant-context.service.ts
+++ b/src/services/tenant-context.service.ts
@@ -15,6 +15,7 @@ import type {
 const cloneTenant = (tenant: TenantSnapshot): TenantSnapshot => ({
   ...tenant,
   microsoft: tenant.microsoft ? { ...tenant.microsoft } : undefined,
+  qdrant: tenant.qdrant ? { ...tenant.qdrant } : undefined,
 });
 
 @Injectable()

--- a/src/services/tenant.service.spec.ts
+++ b/src/services/tenant.service.spec.ts
@@ -32,6 +32,10 @@ describe('TenantService.createWorkspaceHandler', () => {
       GRAPH_CLIENT_ID: 'client-id',
       GRAPH_CLIENT_SECRET: 'secret-value',
     },
+    qdrant: {
+      QDRANT_URL: 'https://qdrant.local',
+      QDRANT_API_KEY: 'qdrant-secret',
+    },
   };
 
   let tenantService: TenantService;
@@ -155,12 +159,15 @@ describe('TenantService.createWorkspaceHandler', () => {
       assert.equal(tenantSnapshot.id, tenant.id);
       assert.equal(tenantSnapshot.microsoft?.GRAPH_TENANT_ID, workspaceTenantId);
       assert.ok(!('GRAPH_CLIENT_SECRET' in (tenantSnapshot.microsoft ?? {})));
+      assert.equal(tenantSnapshot.qdrant?.QDRANT_URL, tenant.qdrant?.QDRANT_URL);
+      assert.ok(!('QDRANT_API_KEY' in (tenantSnapshot.qdrant ?? {})));
       assert.strictEqual(getPrismaClient(), prisma);
       assert.deepEqual(getMetadata(), {
         source: 'workspaceTenantId',
         identifier: workspaceTenantId,
       });
       assert.strictEqual(getSecrets(), capturedSecrets);
+      assert.ok(capturedSecrets.qdrant?.apiKey);
       return 'success';
     });
 

--- a/src/services/tenant.service.ts
+++ b/src/services/tenant.service.ts
@@ -295,7 +295,10 @@ export class TenantService {
     metadata: TenantContextMetadata,
   ): Promise<TenantContextSnapshot> {
     await this.ensureSecretBundle(tenant);
-    const safeTenant = tenant.microsoft?.GRAPH_CLIENT_SECRET
+    const requiresSanitization = Boolean(
+      tenant.microsoft?.GRAPH_CLIENT_SECRET || tenant.qdrant?.QDRANT_API_KEY,
+    );
+    const safeTenant = requiresSanitization
       ? this.secretVault.sanitizeTenant(tenant)
       : (tenant as TenantContextSnapshot['tenant']);
     const secrets =
@@ -323,7 +326,7 @@ export class TenantService {
       return;
     }
 
-    if (tenant.microsoft?.GRAPH_CLIENT_SECRET) {
+    if (tenant.microsoft?.GRAPH_CLIENT_SECRET || tenant.qdrant?.QDRANT_API_KEY) {
       this.secretVault.captureFromTenant(tenant);
       return;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,16 +11,23 @@ export interface TenantMicrosoftConfig {
   GRAPH_SCOPE?: string;
 }
 
+export interface TenantQdrantConfig {
+  QDRANT_URL: string;
+  QDRANT_API_KEY?: string;
+}
+
 export interface TenantDoc {
   id: string;
   name?: string;
   active?: boolean;
   db: string;
   microsoft?: TenantMicrosoftConfig;
+  qdrant?: TenantQdrantConfig;
 }
 
-export type TenantSnapshot = Omit<TenantDoc, 'microsoft'> & {
+export type TenantSnapshot = Omit<TenantDoc, 'microsoft' | 'qdrant'> & {
   readonly microsoft?: Omit<TenantMicrosoftConfig, 'GRAPH_CLIENT_SECRET'>;
+  readonly qdrant?: Omit<TenantQdrantConfig, 'QDRANT_API_KEY'>;
 };
 
 export interface ResolveInput {
@@ -53,5 +60,8 @@ export interface TenantContextState extends TenantContextSnapshot {
 export interface TenantSecretBundle {
   readonly microsoft?: {
     readonly clientSecret: KeyObject;
+  };
+  readonly qdrant?: {
+    readonly apiKey: KeyObject;
   };
 }


### PR DESCRIPTION
## Summary
- extend tenant typing and secret vault handling to capture Qdrant configuration and API keys per tenant
- ensure tenant context snapshots and services sanitise Qdrant secrets while keeping them accessible via the secret bundle
- document the new Qdrant configuration structure and secret handling across the tenancy package

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d26496c5e08325bd289fe0182941de