### PR TITLE
feat: align email model with metadata schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ O objetivo deste guia é servir como um "read absurdo de detalhado" para equipes
 npm install @donna/tenancy
 ```
 
+#### Metadados de emails
+
+O modelo `Email` segue o schema abaixo, alinhado ao payload de metadados processado pelos consumidores:
+
+| Campo | Tipo | Observações |
+| --- | --- | --- |
+| `summary` | `string` | Resumo conciso da mensagem. |
+| `tags` | `string[]` | Lista de categorias para triagem. |
+| `needsReply` | `boolean` | Indica se alguma ação é necessária. |
+| `importance` | `high \| medium \| low` | Importância percebida. |
+| `type` | `string` | Categoria geral da mensagem (ex.: `email`, `support`). |
+| `threadId` | `string` | Identificador de thread para agrupamento. |
+| `detectedEntities` | `string[]` | Entidades extraídas do conteúdo. |
+| `sentiment` | `positive \| neutral \| negative` | Sentimento predominante detectado. |
+| `notify` | `boolean` | Se o usuário deve ser notificado imediatamente. |
+| `notifyTone` | `string` | `positive`, `negative` ou vazio. |
+| `notifyReason` | `string` | Motivo da notificação. |
+| `notifyMessage` | `string` | Mensagem pronta para o usuário. |
+| `shouldEscalate` | `boolean` | Se deve ser escalado para análise avançada. |
+| `isAutomated` | `boolean` | Define se foi gerado automaticamente. |
+
 O pacote é compatível com **NestJS 9+** e **Prisma 5+**. Não é necessário instalar `firebase-admin`, `@prisma/client` ou `ioredis` manualmente, pois eles já são dependências do pacote.
 
 ---

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,29 +122,48 @@ enum FileType {
   VIDEO
 }
 
+enum EmailImportance {
+  high
+  medium
+  low
+}
+
+enum EmailSentiment {
+  positive
+  neutral
+  negative
+}
+
 // Emails
 model Email {
-  id               String    @id @default(uuid())
-  emailIdExternal  String    @unique @map("email_id_external")
-  userId           String?   @map("user_id")
+  id               String           @id @default(uuid())
+  emailIdExternal  String           @unique @map("email_id_external")
+  userId           String?          @map("user_id")
   subject          String
   body             String
-  from             String    @map("from_email")
-  to               String[]  @map("to_emails")
-  isRead           Boolean   @default(false) @map("is_read")
-  isDraft          Boolean   @default(false) @map("is_draft")
-  flagged          Boolean   @default(false)
-  importance       String?
-  threadId         String?   @map("thread_id")
-  timestamp        DateTime? @map("timestamp")
-  webLink          String?   @map("web_link")
-  status           String    @default("open")
-  tags             String[]  @default([])
-  summary          String?
-  needsReply       Boolean?  @map("needs_reply")
-  type             String?
-  cleanText        String?   @map("clean_text")
-  detectedEntities String[]  @default([]) @map("detected_entities")
+  from             String           @map("from_email")
+  to               String[]         @map("to_emails")
+  isRead           Boolean          @default(false) @map("is_read")
+  isDraft          Boolean          @default(false) @map("is_draft")
+  flagged          Boolean          @default(false)
+  importance       EmailImportance  @default(medium)
+  threadId         String           @map("thread_id")
+  timestamp        DateTime?        @map("timestamp")
+  webLink          String?          @map("web_link")
+  status           String           @default("open")
+  tags             String[]         @default([])
+  summary          String
+  needsReply       Boolean          @default(false) @map("needs_reply")
+  type             String           @default("email")
+  cleanText        String?          @map("clean_text")
+  detectedEntities String[]         @default([]) @map("detected_entities")
+  sentiment        EmailSentiment   @default(neutral)
+  notify           Boolean          @default(false)
+  notifyTone       String           @default("") @map("notify_tone")
+  notifyReason     String           @default("") @map("notify_reason")
+  notifyMessage    String           @default("") @map("notify_message")
+  shouldEscalate   Boolean          @default(false) @map("should_escalate")
+  isAutomated      Boolean          @default(false) @map("is_automated")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt


### PR DESCRIPTION
## Summary
- align the Prisma email model with the new metadata schema, including enums for importance and sentiment plus notification fields
- document the supported email metadata fields in the README for quick reference

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d39457aaa08325807ae2882609e9fa