### PR TITLE
feat: resolve tenant context by user phone

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -33,11 +33,13 @@ export type TenantSnapshot = Omit<TenantDoc, 'microsoft' | 'qdrant'> & {
 export interface ResolveInput {
   tenantId?: string;
   userId?: string;
+  userPhoneNumber?: string;
 }
 
 export type TenantContextSource =
   | 'tenantId'
   | 'userId'
+  | 'userPhoneNumber'
   | 'workspaceTenantId'
   | 'microsoftTenantId';
 


### PR DESCRIPTION
## Summary
- allow ResolveInput to accept user phone numbers and track the source in context metadata
- resolve tenant contexts and Prisma clients through user phone lookups in Firestore when provided
- document the new workflow for phone-based resolution in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6237f816c8325bad0808d1b428504