### PR TITLE
Ensure package metadata is available for runtime version lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "files": ["dist", "prisma"],
   "scripts": {
     "build": "npm run clean && npm run build:esm && npm run build:cjs",
+    "postbuild": "node scripts/postbuild.js",
     "build:esm": "tsc -p tsconfig.build.esm.json",
     "build:cjs": "tsc -p tsconfig.build.cjs.json",
     "build:test": "tsc -p tsconfig.test.json",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -1,0 +1,15 @@
+// Dependencies
+const { copyFileSync, mkdirSync } = require('node:fs');
+const { dirname, resolve } = require('node:path');
+
+// Utils
+const copyPackageJson = () => {
+  const sourcePath = resolve(__dirname, '..', 'package.json');
+  const targetPath = resolve(__dirname, '..', 'dist', 'package.json');
+
+  mkdirSync(dirname(targetPath), { recursive: true });
+  copyFileSync(sourcePath, targetPath);
+};
+
+// Execution
+copyPackageJson();


### PR DESCRIPTION
## Summary
- add a postbuild script that copies the package metadata into the dist directory
- invoke the postbuild step from the existing build pipeline so runtime version checks can read package.json

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dab106716c83259f2ca447ebea247d