### PR TITLE
Restore KeyObject handling in tenant secret vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Cofre em memória que mantém secrets sensíveis fora do snapshot compartilhado.
 | Método | Assinatura | Descrição |
 | --- | --- | --- |
 | `sanitizeTenant` | `(tenant: TenantDoc) => TenantSnapshot` | Remove `GRAPH_CLIENT_SECRET` e expõe o bloco de Qdrant conforme persistido (incluindo `QDRANT_API_KEY`, quando presente). Objetos internos são congelados.
-| `captureFromTenant` | `(tenant: TenantDoc) => TenantSecretBundle` | Constrói bundle imutável com secrets Microsoft e Qdrant preservados como `string`.
+| `captureFromTenant` | `(tenant: TenantDoc) => TenantSecretBundle` | Constrói bundle imutável com secrets Microsoft e Qdrant preservados como `KeyObject`.
 | `getSecrets` | `(tenantId: string) => TenantSecretBundle \| undefined` | Recupera bundle previamente capturado.
 | `clearSecrets` | `(tenantId: string) => void` | Remove segredos do cofre.
 
@@ -309,7 +309,7 @@ export function createWorkspacePayloadRunner<TPayload extends WorkspacePayload, 
 | `TenantQdrantConfig` | Configuração do Qdrant (`QDRANT_URL`, `QDRANT_API_KEY?`). |
 | `TenantDoc` | Documento completo do tenant no Firestore (`id`, `db`, `name?`, `active?`, `microsoft?`, `qdrant?`). |
 | `TenantSnapshot` | Versão sanitizada compartilhada no contexto (sem `GRAPH_CLIENT_SECRET`). O bloco `qdrant` mantém `QDRANT_API_KEY?`. |
-| `TenantSecretBundle` | Secrets imutáveis (`microsoft?.clientSecret`, `qdrant?.apiKey`), ambos como `string`. |
+| `TenantSecretBundle` | Secrets imutáveis (`microsoft?.clientSecret`, `qdrant?.apiKey`), ambos como `KeyObject`. |
 | `ResolveInput` | Entrada aceita por `getPrismaFor`/`withTenantContext` (`tenantId?`, `userId?`, `userPhoneNumber?`). |
 | `TenantContextSource` | Origem do contexto (`'tenantId' | 'userId' | 'userPhoneNumber' | 'workspaceTenantId' | 'microsoftTenantId'`). |
 | `TenantContextMetadata` | Metadados (`source`, `identifier`). |

--- a/src/services/tenant-secret-vault.service.spec.ts
+++ b/src/services/tenant-secret-vault.service.spec.ts
@@ -28,7 +28,18 @@ describe('TenantSecretVaultService', () => {
     const initialBundle = vault.captureFromTenant(baseTenant);
 
     assert.ok(initialBundle.microsoft?.clientSecret);
+    assert.equal(typeof initialBundle.microsoft?.clientSecret.export, 'function');
+    assert.strictEqual(
+      initialBundle.microsoft?.clientSecret.export().toString('utf8'),
+      baseTenant.microsoft!.GRAPH_CLIENT_SECRET,
+    );
+
     assert.ok(initialBundle.qdrant?.apiKey);
+    assert.equal(typeof initialBundle.qdrant?.apiKey.export, 'function');
+    assert.strictEqual(
+      initialBundle.qdrant?.apiKey.export().toString('utf8'),
+      baseTenant.qdrant!.QDRANT_API_KEY,
+    );
 
     const sanitizedTenant: TenantDoc = {
       ...baseTenant,
@@ -45,9 +56,14 @@ describe('TenantSecretVaultService', () => {
 
     assert.strictEqual(recaptured.microsoft?.clientSecret, initialBundle.microsoft?.clientSecret);
     assert.ok(recaptured.qdrant?.apiKey);
+    assert.strictEqual(
+      recaptured.qdrant?.apiKey.export().toString('utf8'),
+      baseTenant.qdrant!.QDRANT_API_KEY,
+    );
 
     const stored = vault.getSecrets(baseTenant.id);
     assert.strictEqual(stored?.microsoft?.clientSecret, initialBundle.microsoft?.clientSecret);
     assert.ok(stored?.qdrant?.apiKey);
+    assert.equal(typeof stored?.qdrant?.apiKey.export, 'function');
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 // Dependencies
 import type { PrismaClient } from '@prisma/client';
+import type { KeyObject } from 'node:crypto';
 // Types
 export interface TenantMicrosoftConfig {
   GRAPH_TENANT_ID: string;
@@ -59,9 +60,9 @@ export interface TenantContextState extends TenantContextSnapshot {
 
 export interface TenantSecretBundle {
   readonly microsoft?: {
-    readonly clientSecret: string;
+    readonly clientSecret: KeyObject;
   };
   readonly qdrant?: {
-    readonly apiKey: string;
+    readonly apiKey: KeyObject;
   };
 }


### PR DESCRIPTION
## Summary
- type tenant secret bundles with KeyObject values and preserve existing keys when recapturing
- convert captured string secrets into KeyObjects and keep documentation aligned
- extend tests to ensure returned secrets expose export functionality

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dabaaaeac48325b4b5156329fe2bfe